### PR TITLE
avoid nil entries in user_ids array

### DIFF
--- a/lib/extended_watchers_issue_patch.rb
+++ b/lib/extended_watchers_issue_patch.rb
@@ -15,7 +15,7 @@ module ExtendedWatchersIssuePatch
             Project.allowed_to_condition(user, :view_issues, options) do |role, user|
               # Keep the code DRY
               if [ 'default', 'own' ].include?(role.issues_visibility)
-                user_ids = [user.id] + user.groups.map(&:id)
+                user_ids = [user.id] + user.groups.map(&:id).compact
                 watched_issues = Issue.watched_by(user).map(&:id)
                 watched_issues_clause = watched_issues.empty? ? "" : " OR #{table_name}.id IN (#{watched_issues.join(',')})"
               end


### PR DESCRIPTION
in some cases
- multi project environment in one redmine instance
- cross project textual reference via #ticket-id in description-text
the result of user.group.map(&:id) could contain nil entries, which
causes later on in a mysql-statement problems.