### PR TITLE
[FIX] Compatibility with Watcher Groups plugin

### DIFF
--- a/lib/extended_watchers_issue_patch.rb
+++ b/lib/extended_watchers_issue_patch.rb
@@ -44,7 +44,7 @@ module ExtendedWatchersIssuePatch
           return true if visible
 
           if (usr || User.current).logged?
-            visible =  self.watched_by?(usr)
+            visible =  self.watched_by?(usr || User.current)
           end
 
           logger.error "visible_with_extwatch #{visible}"


### PR DESCRIPTION
In some cases, when combined with watcher groups plugin, this may cause 500 http error when consulting an issue linked to another issue with at least one watcher groups defined.